### PR TITLE
New endpoints: GetDeviceLocalCredentialAsync, RotateLocalAdminPassword

### DIFF
--- a/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphDeviceLocalCredentialsClient.cs
+++ b/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphDeviceLocalCredentialsClient.cs
@@ -1,0 +1,15 @@
+﻿using SlimLib.Auth.Azure;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SlimLib.Microsoft.Graph
+{
+    public interface ISlimGraphDeviceLocalCredentialsClient
+    {
+        Task<JsonElement> GetDeviceLocalCredentialAsync(IAzureTenant tenant, Guid deviceID, ScalarRequestOptions? options = default, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<JsonElement> GetDeviceLocalCredentialsAsync(IAzureTenant tenant, ListRequestOptions? options = default, CancellationToken cancellationToken = default);
+    }
+}

--- a/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphManagedDevicesClient.cs
+++ b/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphManagedDevicesClient.cs
@@ -45,5 +45,6 @@ namespace SlimLib.Microsoft.Graph
         IAsyncEnumerable<JsonElement> GetRemoteActionAuditsAsync(IAzureTenant tenant, ListRequestOptions? options = default, CancellationToken cancellationToken = default);
         IAsyncEnumerable<JsonElement> GetDeviceHealthScriptStatesAsync(IAzureTenant tenant, Guid deviceID, ListRequestOptions? options = default, CancellationToken cancellationToken = default);
         IAsyncEnumerable<JsonElement> GetDeviceRunStatesAsync(IAzureTenant tenant, string deviceHealthScriptId, ListRequestOptions? options = default, CancellationToken cancellationToken = default);
+        Task RotateLocalAdminPasswordAsync(IAzureTenant tenant, Guid deviceID, ScalarRequestOptions? options = default, CancellationToken cancellationToken = default);
     }
 }

--- a/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphServiceClient.cs
+++ b/SlimLib.Microsoft.Graph/ClientInterfaces/ISlimGraphServiceClient.cs
@@ -19,5 +19,6 @@
         ISlimGraphSubscribedSkusClient SubscribedSkus { get; }
         ISlimGraphPrivilegedAccessClient PrivilegedAccess { get; }
         ISlimGraphUsersClient Users { get; }
+        ISlimGraphDeviceLocalCredentialsClient DeviceLocalCredentials { get; }
     }
 }

--- a/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.DeviceLocalCredentials.cs
+++ b/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.DeviceLocalCredentials.cs
@@ -1,0 +1,34 @@
+﻿using SlimLib.Auth.Azure;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SlimLib.Microsoft.Graph
+{
+    partial class SlimGraphClientImpl
+    {
+        async Task<JsonElement> ISlimGraphDeviceLocalCredentialsClient.GetDeviceLocalCredentialAsync(IAzureTenant tenant, Guid deviceID, ScalarRequestOptions? options, CancellationToken cancellationToken)
+        {
+            var link = BuildLink(options, $"directory/deviceLocalCredentials/{deviceID}");
+
+            //Throws an error wtihout a user agent
+            return await GetAsync(tenant, link, new RequestHeaderOptions { UserAgent = "Mozilla/5.0 (Windows NT 10; Win64; x64; rv:60.0) Gecko/20100101 Firefox/60.0" }, cancellationToken).ConfigureAwait(false);
+        }
+
+        async IAsyncEnumerable<JsonElement> ISlimGraphDeviceLocalCredentialsClient.GetDeviceLocalCredentialsAsync(IAzureTenant tenant, ListRequestOptions? options, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var nextLink = BuildLink(options, "directory/deviceLocalCredentials");
+
+            await foreach (var item in GetArrayAsync(tenant, nextLink, options, cancellationToken))
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    yield break;
+
+                yield return item;
+            }
+        }
+    }
+}

--- a/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.ManagedDevices.cs
+++ b/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.ManagedDevices.cs
@@ -288,5 +288,11 @@ namespace SlimLib.Microsoft.Graph
                 yield return item;
             }
         }
+        async Task ISlimGraphManagedDevicesClient.RotateLocalAdminPasswordAsync(IAzureTenant tenant, Guid deviceID, ScalarRequestOptions? options, CancellationToken cancellationToken)
+        {
+            var link = BuildLink(options, $"deviceManagement/managedDevices/{deviceID}/rotateLocalAdminPassword");
+
+            await PostAsync(tenant, null, link, new RequestHeaderOptions(), cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.cs
+++ b/SlimLib.Microsoft.Graph/Impl/SlimGraphClientImpl.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace SlimLib.Microsoft.Graph
 {
-    internal sealed partial class SlimGraphClientImpl : ISlimGraphAdministrativeUnitsClient, ISlimGraphApplicationsClient, ISlimGraphAuditEventsClient, ISlimGraphAuditLogsClient, ISlimGraphDeviceManagementReportsClient, ISlimGraphOrganizationsClient, ISlimGraphOrgContactsClient, ISlimGraphDevicesClient, ISlimGraphDirectoryRolesClient, ISlimGraphDetectedAppsClient, ISlimGraphMobileAppsClient, ISlimGraphManagedDevicesClient, ISlimGraphGroupsClient, ISlimGraphSubscribedSkusClient, ISlimGraphServicePrincipalsClient, ISlimGraphPrivilegedAccessClient, ISlimGraphUsersClient
+    internal sealed partial class SlimGraphClientImpl : ISlimGraphAdministrativeUnitsClient, ISlimGraphApplicationsClient, ISlimGraphAuditEventsClient, ISlimGraphAuditLogsClient, ISlimGraphDeviceManagementReportsClient, ISlimGraphOrganizationsClient, ISlimGraphOrgContactsClient, ISlimGraphDevicesClient, ISlimGraphDirectoryRolesClient, ISlimGraphDetectedAppsClient, ISlimGraphMobileAppsClient, ISlimGraphManagedDevicesClient, ISlimGraphGroupsClient, ISlimGraphSubscribedSkusClient, ISlimGraphServicePrincipalsClient, ISlimGraphPrivilegedAccessClient, ISlimGraphUsersClient, ISlimGraphDeviceLocalCredentialsClient
     {
         private readonly IAuthenticationProvider authenticationProvider;
         private readonly HttpClient httpClient;
@@ -191,7 +191,10 @@ namespace SlimLib.Microsoft.Graph
                 logger.LogDebug("Setting HTTP header Prefer: return=minimal");
                 request.Headers.Add("Prefer", "return=minimal");
             }
-
+            if (!string.IsNullOrEmpty(options?.UserAgent))
+            {
+                request.Headers.Add("User-Agent", options.UserAgent);
+            }
             var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (options?.PreferMinimal == true)

--- a/SlimLib.Microsoft.Graph/Options/RequestHeaderOptions.cs
+++ b/SlimLib.Microsoft.Graph/Options/RequestHeaderOptions.cs
@@ -4,5 +4,6 @@
     {
         public bool PreferMinimal { get; set; }
         public bool ConsistencyLevelEventual { get; set; }
+        public string? UserAgent { get; set; }
     }
 }

--- a/SlimLib.Microsoft.Graph/SlimGraphClient.cs
+++ b/SlimLib.Microsoft.Graph/SlimGraphClient.cs
@@ -31,5 +31,6 @@ namespace SlimLib.Microsoft.Graph
         public ISlimGraphSubscribedSkusClient SubscribedSkus => impl;
         public ISlimGraphPrivilegedAccessClient PrivilegedAccess => impl;
         public ISlimGraphUsersClient Users => impl;
+        public ISlimGraphDeviceLocalCredentialsClient DeviceLocalCredentials => impl;
     }
 }


### PR DESCRIPTION
New endpoints:
- directory/deviceLocalCredentials
- directory/deviceLocalCredentials/{deviceID}
- deviceManagement/managedDevices/{deviceID}/rotateLocalAdminPassword

User-Agent is needed for the endpoint `directory/deviceLocalCredentials/{deviceID}`, or else it throws the below error:
![image](https://github.com/realmjoin/SlimLib.Microsoft.Graph/assets/24998910/7d5d3812-e1b6-4048-befc-62c928af7c19)

